### PR TITLE
Apply --legacy flag when using Xcode 16's xcresulttool

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -6,14 +6,20 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
-    ast (2.4.0)
+    ast (2.4.2)
     diff-lcs (1.3)
-    jaro_winkler (1.5.3)
-    parallel (1.17.0)
-    parser (2.6.4.1)
-      ast (~> 2.4.0)
-    rainbow (3.0.0)
+    json (2.7.2)
+    language_server-protocol (3.17.0.3)
+    parallel (1.25.1)
+    parser (3.3.4.0)
+      ast (~> 2.4.1)
+      racc
+    racc (1.8.1)
+    rainbow (3.1.1)
     rake (13.0.1)
+    regexp_parser (2.9.2)
+    rexml (3.3.4)
+      strscan
     rspec (3.8.0)
       rspec-core (~> 3.8.0)
       rspec-expectations (~> 3.8.0)
@@ -27,15 +33,22 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.8.0)
     rspec-support (3.8.2)
-    rubocop (0.73.0)
-      jaro_winkler (~> 1.5.1)
+    rubocop (1.65.1)
+      json (~> 2.3)
+      language_server-protocol (>= 3.17.0)
       parallel (~> 1.10)
-      parser (>= 2.6)
+      parser (>= 3.3.0.2)
       rainbow (>= 2.2.2, < 4.0)
+      regexp_parser (>= 2.4, < 3.0)
+      rexml (>= 3.2.5, < 4.0)
+      rubocop-ast (>= 1.31.1, < 2.0)
       ruby-progressbar (~> 1.7)
-      unicode-display_width (>= 1.4.0, < 1.7)
-    ruby-progressbar (1.10.1)
-    unicode-display_width (1.6.0)
+      unicode-display_width (>= 2.4.0, < 3.0)
+    rubocop-ast (1.32.0)
+      parser (>= 3.3.1.0)
+    ruby-progressbar (1.13.0)
+    strscan (3.1.0)
+    unicode-display_width (2.5.0)
 
 PLATFORMS
   ruby
@@ -44,8 +57,8 @@ DEPENDENCIES
   bundler (~> 2.0)
   rake (~> 13.0)
   rspec (~> 3.0)
-  rubocop
+  rubocop (~> 1.65)
   xcresult!
 
 BUNDLED WITH
-   2.0.2
+   2.5.10

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    xcresult (0.2.1)
+    xcresult (0.2.2)
 
 GEM
   remote: https://rubygems.org/

--- a/lib/xcresult/parser.rb
+++ b/lib/xcresult/parser.rb
@@ -28,7 +28,7 @@ module XCResult
       # Maps ids into ActionTestPlanRunSummaries by executing xcresulttool to get JSON
       # containing specific information for each test summary
       @action_test_plan_summaries = ids.map do |id|
-        raw = execute_cmd("xcrun xcresulttool get --format json --path #{path} --id #{id}")
+        raw = xcresulttool_get_command("--format json --path #{path} --id #{id}")
         json = JSON.parse(raw)
         XCResult::ActionTestPlanRunSummaries.new(json)
       end
@@ -77,9 +77,21 @@ module XCResult
     private
 
     def get_result_bundle_json(id: nil)
-      cmd = "xcrun xcresulttool get --format json --path #{path}"
+      cmd = xcresulttool_get_command("--format json --path #{path}")
       cmd += " --id #{id}" if id
       execute_cmd(cmd)
+    end
+
+    def xcresulttool_get_command(args)
+      # Find the current xcresulttool version based on Fastlane's implementation
+      # xcresulttool version 23024, format version 3.53 (current)
+      match = `xcrun xcresulttool version`.match(/xcresulttool version (?<version>\d+),/)
+      version = match[:version]&.to_f
+
+      requires_legacy = version >= 23_021.0
+      legacy_flag = requires_legacy ? '--legacy' : ''
+  
+      cmd = "xcrun xcresulttool get #{legacy_flag} #{args}"
     end
 
     def execute_cmd(cmd)

--- a/lib/xcresult/parser.rb
+++ b/lib/xcresult/parser.rb
@@ -28,7 +28,7 @@ module XCResult
       # Maps ids into ActionTestPlanRunSummaries by executing xcresulttool to get JSON
       # containing specific information for each test summary
       @action_test_plan_summaries = ids.map do |id|
-        raw = xcresulttool_get_command("--format json --path #{path} --id #{id}")
+        raw = execute_cmd(xcresulttool_command("get", "--format json --path #{path} --id #{id}"))
         json = JSON.parse(raw)
         XCResult::ActionTestPlanRunSummaries.new(json)
       end
@@ -48,7 +48,7 @@ module XCResult
       # Exports all xccovreport files from the report references
       ids.each_with_index.map do |id, i|
         output_path = File.join(destination, "action_#{i}.xccovreport")
-        cmd = "xcrun xcresulttool export --path #{path} --id '#{id}' --output-path #{output_path} --type file"
+        cmd = xcresulttool_command("export", "--path #{path} --id '#{id}' --output-path #{output_path} --type file")
         execute_cmd(cmd)
 
         output_path
@@ -67,7 +67,7 @@ module XCResult
       # Exports all xcovarchive directories from the archive references
       ids.each_with_index.map do |id, i|
         output_path = File.join(destination, "action_#{i}.xccovarchive")
-        cmd = "xcrun xcresulttool export --path #{path} --id '#{id}' --output-path #{output_path} --type directory"
+        cmd = xcresulttool_command("export", "--path #{path} --id '#{id}' --output-path #{output_path} --type directory")
         execute_cmd(cmd)
 
         output_path
@@ -77,12 +77,12 @@ module XCResult
     private
 
     def get_result_bundle_json(id: nil)
-      cmd = xcresulttool_get_command("--format json --path #{path}")
+      cmd = xcresulttool_command("get", "--format json --path #{path}")
       cmd += " --id #{id}" if id
       execute_cmd(cmd)
     end
 
-    def xcresulttool_get_command(args)
+    def xcresulttool_command(subcommand, args)
       # Find the current xcresulttool version based on Fastlane's implementation
       # xcresulttool version 23024, format version 3.53 (current)
       match = `xcrun xcresulttool version`.match(/xcresulttool version (?<version>\d+),/)
@@ -91,7 +91,7 @@ module XCResult
       requires_legacy = version >= 23_021.0
       legacy_flag = requires_legacy ? '--legacy' : ''
   
-      cmd = "xcrun xcresulttool get #{legacy_flag} #{args}"
+      cmd = "xcrun xcresulttool #{subcommand} #{legacy_flag} #{args}"
     end
 
     def execute_cmd(cmd)

--- a/lib/xcresult/parser.rb
+++ b/lib/xcresult/parser.rb
@@ -86,12 +86,13 @@ module XCResult
       # Find the current xcresulttool version based on Fastlane's implementation
       # xcresulttool version 23024, format version 3.53 (current)
       match = `xcrun xcresulttool version`.match(/xcresulttool version (?<version>\d+),/)
+
       version = match[:version]&.to_f
 
       requires_legacy = version >= 23_021.0
-      legacy_flag = requires_legacy ? '--legacy' : ''
+      legacy_flag = requires_legacy ? ' --legacy' : ''
   
-      cmd = "xcrun xcresulttool #{subcommand} #{legacy_flag} #{args}"
+      cmd = "xcrun xcresulttool #{subcommand}#{legacy_flag} #{args}"
     end
 
     def execute_cmd(cmd)

--- a/lib/xcresult/version.rb
+++ b/lib/xcresult/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module XCResult
-  VERSION = '0.2.1'
+  VERSION = '0.2.2'
 end

--- a/spec/xcresult_spec.rb
+++ b/spec/xcresult_spec.rb
@@ -34,6 +34,20 @@ RSpec.describe "XCResult Test Summaries" do
   let(:summary_id) { "0~2LVFAe2LWJ7FCnOsKan5UgGk7WChVJYuZlxPILKyxdpmfjsMrwjBJ2wUhaJQJ36Per_GRUfTI1cKeO2QiGvB8Q==" }
   let!(:subject) { XCResult::Parser.new(path: path) }
 
+  it 'has a version number' do
+    expect(XCResult::VERSION).not_to be nil
+  end
+  
+  it 'parse xccov report paths' do
+    require 'tmpdir'
+    destination = Dir.mktmpdir
+  
+    parser = XCResult::Parser.new(path: path)
+    export_xccovreport_paths = parser.export_xccovreports(destination: destination)
+  
+    expect(export_xccovreport_paths.count).to eq(1)  
+  end
+
   it 'parse test plan summaries' do
     summaries = subject.action_test_plan_summaries
 

--- a/spec/xcresult_spec.rb
+++ b/spec/xcresult_spec.rb
@@ -21,7 +21,13 @@ RSpec.describe XCResult do
   it 'parse test plan summaries' do
     parser = XCResult::Parser.new(path: path)
 
-    expect(parser).to receive(:execute_cmd).with("xcrun xcresulttool get --format json --path #{path} --id #{summary_id}").and_call_original
+    match = `xcrun xcresulttool version`.match(/xcresulttool version (?<version>\d+),/)
+    version = match[:version]&.to_f
+
+    requires_legacy = version >= 23_021.0
+    legacy_flag = requires_legacy ? '--legacy' : ''
+
+    expect(parser).to receive(:execute_cmd).with("xcrun xcresulttool get #{legacy_flag} --format json --path #{path} --id #{summary_id}").and_call_original
 
     summaries = parser.action_test_plan_summaries
 

--- a/spec/xcresult_spec.rb
+++ b/spec/xcresult_spec.rb
@@ -32,24 +32,24 @@ end
 RSpec.describe "XCResult Test Summaries" do
   let(:path) { File.absolute_path("./spec/fixtures/Test.xcresult") }
   let(:summary_id) { "0~2LVFAe2LWJ7FCnOsKan5UgGk7WChVJYuZlxPILKyxdpmfjsMrwjBJ2wUhaJQJ36Per_GRUfTI1cKeO2QiGvB8Q==" }
-  let!(:subject) { XCResult::Parser.new(path: path) }
 
   it 'has a version number' do
     expect(XCResult::VERSION).not_to be nil
   end
-  
+
   it 'parse xccov report paths' do
     require 'tmpdir'
     destination = Dir.mktmpdir
-  
+
     parser = XCResult::Parser.new(path: path)
     export_xccovreport_paths = parser.export_xccovreports(destination: destination)
-  
+
     expect(export_xccovreport_paths.count).to eq(1)  
   end
 
   it 'parse test plan summaries' do
-    summaries = subject.action_test_plan_summaries
+    parser = XCResult::Parser.new(path: path)
+    summaries = parser.action_test_plan_summaries
 
     testable_summary = summaries[0].summaries[0].testable_summaries[0]
 

--- a/spec/xcresult_spec.rb
+++ b/spec/xcresult_spec.rb
@@ -49,6 +49,12 @@ RSpec.describe "XCResult Test Summaries" do
 
   it 'parse test plan summaries' do
     parser = XCResult::Parser.new(path: path)
+
+    expect(parser).to receive(:execute_cmd).with(lambda { |command|
+      is_valid_xcresulttool_command_regex = /^xcrun xcresulttool get( --legacy)? --format json --path .+ --id [a-zA-Z0-9_\~\=]+$/
+      is_valid_xcresulttool_command_regex.match(command) != nil
+     }).and_call_original
+
     summaries = parser.action_test_plan_summaries
 
     testable_summary = summaries[0].summaries[0].testable_summaries[0]

--- a/spec/xcresult_spec.rb
+++ b/spec/xcresult_spec.rb
@@ -1,35 +1,41 @@
 # frozen_string_literal: true
 
-RSpec.describe XCResult do
+RSpec.describe "XCResult Version" do
   let(:path) { File.absolute_path("./spec/fixtures/Test.xcresult") }
   let(:summary_id) { "0~2LVFAe2LWJ7FCnOsKan5UgGk7WChVJYuZlxPILKyxdpmfjsMrwjBJ2wUhaJQJ36Per_GRUfTI1cKeO2QiGvB8Q==" }
+  let!(:subject) { XCResult::Parser.new(path: path) }
+  let(:command) { subject.send(:xcresulttool_command, "get", "--format json --path #{path} --id #{summary_id}") }
 
-  it 'has a version number' do
-    expect(XCResult::VERSION).not_to be nil
+  before do
+    allow(subject).to receive(:`).with('xcrun xcresulttool version').and_return(xcresulttool_version)
   end
 
-  it 'parse xccov report paths' do
-    require 'tmpdir'
-    destination = Dir.mktmpdir
+  context 'with below 23_021.0 ' do
+    let(:xcresulttool_version) { 'xcresulttool version 23020, format version 3.53 (current)' }
+    let(:expected) { "xcrun xcresulttool get --format json --path #{path} --id #{summary_id}" }
 
-    parser = XCResult::Parser.new(path: path)
-    export_xccovreport_paths = parser.export_xccovreports(destination: destination)
-
-    expect(export_xccovreport_paths.count).to eq(1)  
+    it 'should not have --legacy' do
+      expect(command).to eq(expected)
+    end
   end
+
+  context 'with 23_021.0 and above' do
+    let(:xcresulttool_version) { 'xcresulttool version 23022, format version 3.53 (current)' }
+    let(:expected) { "xcrun xcresulttool get --legacy --format json --path #{path} --id #{summary_id}" }
+
+    it 'should have --legacy' do
+      expect(command).to eq(expected)
+    end
+  end
+end
+
+RSpec.describe "XCResult Test Summaries" do
+  let(:path) { File.absolute_path("./spec/fixtures/Test.xcresult") }
+  let(:summary_id) { "0~2LVFAe2LWJ7FCnOsKan5UgGk7WChVJYuZlxPILKyxdpmfjsMrwjBJ2wUhaJQJ36Per_GRUfTI1cKeO2QiGvB8Q==" }
+  let!(:subject) { XCResult::Parser.new(path: path) }
 
   it 'parse test plan summaries' do
-    parser = XCResult::Parser.new(path: path)
-
-    match = `xcrun xcresulttool version`.match(/xcresulttool version (?<version>\d+),/)
-    version = match[:version]&.to_f
-
-    requires_legacy = version >= 23_021.0
-    legacy_flag = requires_legacy ? '--legacy' : ''
-
-    expect(parser).to receive(:execute_cmd).with("xcrun xcresulttool get #{legacy_flag} --format json --path #{path} --id #{summary_id}").and_call_original
-
-    summaries = parser.action_test_plan_summaries
+    summaries = subject.action_test_plan_summaries
 
     testable_summary = summaries[0].summaries[0].testable_summaries[0]
 

--- a/xcresult.gemspec
+++ b/xcresult.gemspec
@@ -25,5 +25,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'bundler', '~> 2.0'
   spec.add_development_dependency 'rake', '~> 13.0'
   spec.add_development_dependency 'rspec', '~> 3.0'
-  spec.add_development_dependency 'rubocop'
+  spec.add_development_dependency 'rubocop', '~> 1.65'
 end


### PR DESCRIPTION
Because of the recent changes in Xcode 16, `xcresulttool` subcommands require the `--legacy` flag to be passed in order to output the previous format.

When this flag is not passed, the subcommands return a non-zero code with the following example message:

```
Error: This command is deprecated and will be removed in a future release, --legacy flag is required to use it.
Usage: xcresulttool get object [--legacy] --path <path> [--id <id>] [--version <version>] [--format <format>]
  See 'xcresulttool get object --help' for more information.
```

This PR is aimed to fix this based on Fastlane's implementation, see https://github.com/fastlane/fastlane/pull/22147 for reference.

Also this changeset bumps `rubocop` to `~> 1.65` because compiling its dependency `jaro_winkler` on the currently locked version (1.5.3) fails on Apple Silicon - this was fixed in 1.5.5 - see https://github.com/tonytonyjan/jaro_winkler/issues/51.