### PR TITLE
Update version detection for `--legacy` flag due to changes in xcresulttool version number

### DIFF
--- a/lib/xcresult/parser.rb
+++ b/lib/xcresult/parser.rb
@@ -87,9 +87,10 @@ module XCResult
       # xcresulttool version 23024, format version 3.53 (current)
       match = `xcrun xcresulttool version`.match(/xcresulttool version (?<version>\d+),/)
 
-      version = match[:version]&.to_f
+      version = match ? match[:version]&.to_f : nil
 
-      requires_legacy = version >= 23_021.0
+      # If version string does not match expected format, assume legacy is required
+      requires_legacy = version.nil? || version >= 23_021.0
       legacy_flag = requires_legacy ? ' --legacy' : ''
   
       cmd = "xcrun xcresulttool #{subcommand}#{legacy_flag} #{args}"

--- a/lib/xcresult/parser.rb
+++ b/lib/xcresult/parser.rb
@@ -85,7 +85,8 @@ module XCResult
     def xcresulttool_command(subcommand, args)
       # Find the current xcresulttool version based on Fastlane's implementation
       # xcresulttool version 23024, format version 3.53 (current)
-      match = `xcrun xcresulttool version`.match(/xcresulttool version (?<version>\d+),/)
+      # xcresulttool version 24051.1, schema version: 0.1.0 (legacy commands format version: 3.53)
+      match = `xcrun xcresulttool version`.match(/xcresulttool version (?<version>[0-9\.]+),/)
 
       version = match ? match[:version]&.to_f : nil
 

--- a/lib/xcresult/parser.rb
+++ b/lib/xcresult/parser.rb
@@ -86,7 +86,7 @@ module XCResult
       # Find the current xcresulttool version based on Fastlane's implementation
       # xcresulttool version 23024, format version 3.53 (current)
       # xcresulttool version 24051.1, schema version: 0.1.0 (legacy commands format version: 3.53)
-      match = `xcrun xcresulttool version`.match(/xcresulttool version (?<version>[0-9\.]+),/)
+      match = `xcrun xcresulttool version`.match(/xcresulttool version (?<version>\d+(\.\d+)?),/)
 
       version = match ? match[:version]&.to_f : nil
 

--- a/spec/xcresult_spec.rb
+++ b/spec/xcresult_spec.rb
@@ -35,7 +35,25 @@ RSpec.describe "XCResult Version" do
     it 'should have --legacy' do
       expect(command).to eq(expected)
     end
-  end  
+  end
+
+  context 'with Xcode 26 command line tools version style - non-legacy version' do
+    let(:xcresulttool_version) { 'xcresulttool version 23020.0, schema version: 0.1.0 (legacy commands format version: 3.53)' }
+    let(:expected) { "xcrun xcresulttool get --format json --path #{path} --id #{summary_id}" }
+
+    it 'should not have --legacy' do
+      expect(command).to eq(expected)
+    end
+  end
+
+  context 'with unsupported command line tools version' do
+    let(:xcresulttool_version) { 'no version here' }
+    let(:expected) { "xcrun xcresulttool get --legacy --format json --path #{path} --id #{summary_id}" }
+
+    it 'should have --legacy' do
+      expect(command).to eq(expected)
+    end
+  end
 end
 
 RSpec.describe "XCResult Test Summaries" do

--- a/spec/xcresult_spec.rb
+++ b/spec/xcresult_spec.rb
@@ -27,6 +27,15 @@ RSpec.describe "XCResult Version" do
       expect(command).to eq(expected)
     end
   end
+
+  context 'with Xcode 26 command line tools version style' do
+    let(:xcresulttool_version) { 'xcresulttool version 24051.1, schema version: 0.1.0 (legacy commands format version: 3.53)' }
+    let(:expected) { "xcrun xcresulttool get --legacy --format json --path #{path} --id #{summary_id}" }
+
+    it 'should have --legacy' do
+      expect(command).to eq(expected)
+    end
+  end  
 end
 
 RSpec.describe "XCResult Test Summaries" do


### PR DESCRIPTION
Xcode 16: `xcresulttool version 23024, format version 3.53 (current)`
Xcode 26: `xcresulttool version 24051.1, schema version: 0.1.0 (legacy commands format version: 3.53)`

The regular expression added to determine if the `--legacy` parameter is needed only matched on numeric characters for the version, the new version number has a decimal and would result in a null pointer error being thrown when trying to get the version. Updated to optionally support the decimalised version number. If no match is found, assume it's a newer version and assume `--legacy` is needed in this case as well.

This is the trace seen when this issue this PR resolves is hit:

```
/Users/bamboo/.gem/gems/xcresult-0.2.2/lib/xcresult/parser.rb:90:in `xcresulttool_command': undefined method `[]' for nil:NilClass (NoMethodError)
	from /Users/bamboo/.gem/gems/xcresult-0.2.2/lib/xcresult/parser.rb:80:in `get_result_bundle_json'
	from /Users/bamboo/.gem/gems/xcresult-0.2.2/lib/xcresult/parser.rb:13:in `initialize'
```

