### PR TITLE
Bump up gem version to 0.2.4

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    xcresult (0.2.2)
+    xcresult (0.2.4)
 
 GEM
   remote: https://rubygems.org/

--- a/lib/xcresult/version.rb
+++ b/lib/xcresult/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module XCResult
-  VERSION = '0.2.2'
+  VERSION = '0.2.4'
 end


### PR DESCRIPTION
This PR bumps up gem version to 0.2.4 to release #9

I accidentally created the 0.2.3 tag before upgrading the version.
Therefore, I would like to skip 0.2.3 and make 0.2.4 the official release.