### PR TITLE
Use absolute path to get around Xcode 26.1 crash

### DIFF
--- a/lib/xcresult/parser.rb
+++ b/lib/xcresult/parser.rb
@@ -8,7 +8,7 @@ module XCResult
     attr_accessor :path, :result_bundle_json, :actions_invocation_record
 
     def initialize(path: nil)
-      @path = Shellwords.escape(path)
+      @path = Shellwords.escape(File.expand_path(path))
 
       result_bundle_json_raw = get_result_bundle_json
       @result_bundle_json = JSON.parse(result_bundle_json_raw)


### PR DESCRIPTION
xcresulttool crashes in Xcode 26.1 when attempting to use relative path for the xcresult files. A workaround has been to pass absolute path

Apple discussion: https://developer.apple.com/forums/thread/806401